### PR TITLE
Merge driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+packages/*.package/monticello.meta/version           merge=mcVersion
+packages/*.package/*.class/methodProperties.json     merge=mcMethodProperties
+packages/*.package/*.class/properties.json           merge=mcProperties
+packages/*.package/*.extension/methodProperties.json merge=mcMethodProperties
+packages/*.package/*.extension/properties.json       merge=mcProperties

--- a/notes/content/00_setup/git-merge-driver.md
+++ b/notes/content/00_setup/git-merge-driver.md
@@ -1,0 +1,22 @@
++++
+date = "2016-05-19T14:22:21+02:00"
+prev = "/00_setup/"
+next = "/01_upgrades/"
+title = "Git MergeDriver"
+weight = 10
++++
+
+Due to the dual use of monticello and git, there are some problems with merging.
+Git doesn't know how to merge monticello metadata files, causing a lot of merge conflicts.
+The solution for this problem that was presented in class is manually merging in Smalltalk first, and then committing the merged changes in git.
+
+This process can be automated by using the [filetree merge driver](https://github.com/ThierryGoubier/GitFileTree-MergeDriver).
+Unfortunately, it probably requires Linux or OSX (the merge script itself is a bash script).
+The setup is quite simple:
+
+ * Clone the git repository of the merge driver somewhere where it can stay
+ * Run `make` in the repositories root directory
+
+This will have appended some lines to your git config (`~/.gitconfig`) to register the merge driver.
+Because our repository already contains a `.gitattributes` file which enables the merge driver for the appropriate files, this is all that needs to be done.
+From now on `git merge` should work as expected.

--- a/notes/content/00_setup/index.md
+++ b/notes/content/00_setup/index.md
@@ -3,7 +3,7 @@ chapter = true
 date = "2016-05-17T11:47:09+02:00"
 icon = "<b>0. </b>"
 prev = ""
-next = "/01_upgrades/"
+next = "/00_setup/git-merge-driver/"
 title = "Setup"
 weight = 0
 +++

--- a/notes/content/01_upgrades/index.md
+++ b/notes/content/01_upgrades/index.md
@@ -2,7 +2,7 @@
 chapter = true
 date = "2016-05-18T13:17:12+02:00"
 icon = "<b>1. </b>"
-prev = "/00_setup/"
+prev = "/00_setup/git-merge-driver/"
 next = "/01_upgrades/project-bug/"
 title = "Upgrades"
 weight = 0


### PR DESCRIPTION
Adds a `.gitattributes` file to enable the [merge driver](https://github.com/ThierryGoubier/GitFileTree-MergeDriver) and a wiki page describing its installation.
