### PR TITLE
Fix github language statistics

### DIFF
--- a/notes/themes/.gitattributes
+++ b/notes/themes/.gitattributes
@@ -1,0 +1,1 @@
+learn/* linguist-vendored


### PR DESCRIPTION
Right now Github recognizes our project as being mainly CSS with a lot of Smalltalk and HTML. This is due to the hugo theme containing more code than we have written. This PR fixes this "problem" by marking the theme as ignored by language statistics (see https://github.com/github/linguist for documentation on this).
